### PR TITLE
Fix timing of R response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/), and this 
 
 ## Unreleased
 
+### Fixed
+- `axi_riscv_amos`: Fixed timing of R response (#10).
+
 ## v0.2.0 - 2019-02-21
 
 ### Changed


### PR DESCRIPTION
This fixes #10. The R response is intercepted from the channel and only inserted once the B response is received. Therefore, both the R and the B response are now sent after the memory is updated.