### PR TITLE
amos: Change to incremental burst type

### DIFF
--- a/src/axi_riscv_amos.sv
+++ b/src/axi_riscv_amos.sv
@@ -392,7 +392,7 @@ module axi_riscv_amos #(
                     mst_aw_len_o    = 8'h00;
                     mst_aw_id_o     = id_q;
                     mst_aw_size_o   = size_q;
-                    mst_aw_burst_o  = 2'b00;
+                    mst_aw_burst_o  = axi_pkg::BURST_INCR;
                     mst_aw_lock_o   = 1'b0;
                     mst_aw_cache_o  = cache_q;
                     mst_aw_prot_o   = prot_q;
@@ -732,7 +732,7 @@ module axi_riscv_amos #(
                             mst_ar_id_o     = slv_aw_id_i;
                             mst_ar_len_o    = 8'h00;
                             mst_ar_size_o   = slv_aw_size_i;
-                            mst_ar_burst_o  = 2'b00;
+                            mst_ar_burst_o  = axi_pkg::BURST_INCR;
                             mst_ar_lock_o   = 1'h0;
                             mst_ar_cache_o  = slv_aw_cache_i;
                             mst_ar_prot_o   = slv_aw_prot_i;
@@ -760,7 +760,7 @@ module axi_riscv_amos #(
                     mst_ar_id_o     = id_q;
                     mst_ar_len_o    = 8'h00;
                     mst_ar_size_o   = size_q;
-                    mst_ar_burst_o  = 2'b00;
+                    mst_ar_burst_o  = axi_pkg::BURST_INCR;
                     mst_ar_lock_o   = 1'h0;
                     mst_ar_cache_o  = cache_q;
                     mst_ar_prot_o   = prot_q;


### PR DESCRIPTION
It seems that the most widely supported burst types are INCR and WRAP bursts, at least on
the Xilinx infrastructure. I am pretty confident that most of the infrastructure should have
INCR bursts implemented since this is one of the main benefits of having an AXI-based
infrastructure.

In particular, this change fixes the burst type to incremental of the split RMW sequence, essentially
mitigating an issue of the Xilinx SmartConnect blocks which do not support FIXED bursts.

Two notes:

1. I realize this could also be implemented as a parameter. Given the above assumption I would still prefer to hard-code this in the module since this makes this module, IMHO, a little bit easier to use (no need to worry about).
2. In case it is too controversial of a change, I can also live with a patch outside this repo.
