### PR TITLE
Make handling of illegal ATOPs conform with the axi repo

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -3,7 +3,7 @@ package:
   authors: ["Andreas Kurth <akurth@iis.ee.ethz.ch>", "Samuel Riedel <sriedel@student.ethz.ch>"]
 
 dependencies:
-  axi: { git: "https://github.com/pulp-platform/axi.git", version: 0.35.0 }
+  axi: { git: "https://github.com/pulp-platform/axi.git", version: 0.35.1 }
   common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.11.0 }
   common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.2.1 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/), and this 
 [Semantic Versioning](http://semver.org).
 
 
+## Unreleased
+
+### Added
+
+### Changed
+
+### Fixed
+- `axi_riscv_amos`: Use `axi_pkg::ATOP_R_RESP` to determine the need for an R response.
+
+
 ## 0.3.0 - 2022-03-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/), and this 
 
 ### Fixed
 - `axi_riscv_amos`: Use `axi_pkg::ATOP_R_RESP` to determine the need for an R response.
+- `axi_riscv_amos`: Only treat requests as ATOPs if the two MSBs are nonzero.
 
 
 ## 0.3.0 - 2022-03-11

--- a/src/axi_riscv_amos.sv
+++ b/src/axi_riscv_amos.sv
@@ -271,7 +271,7 @@ module axi_riscv_amos #(
         if (adapter_ready) begin
             atop_valid_d = NONE;
             atop_r_resp_d = 1'b0;
-            if (slv_aw_valid_i && slv_aw_atop_i) begin
+            if (slv_aw_valid_i && (slv_aw_atop_i[5:4] != axi_pkg::ATOP_NONE)) begin
                 // Default is invalid request
                 atop_valid_d = INVALID;
                 // Valid load operation
@@ -346,7 +346,7 @@ module axi_riscv_amos #(
         aw_state_d      = aw_state_q;
 
         // Default control: Block AW channel if...
-        if (slv_aw_valid_i && slv_aw_atop_i) begin
+        if (slv_aw_valid_i && (slv_aw_atop_i[5:4] != axi_pkg::ATOP_NONE)) begin
             // Block if atomic request
             mst_aw_valid_o = 1'b0;
             slv_aw_ready_o = 1'b0;
@@ -377,7 +377,7 @@ module axi_riscv_amos #(
 
             FEEDTHROUGH_AW: begin
                 // Feedthrough slave to master until atomic operation is detected
-                if (slv_aw_valid_i && slv_aw_atop_i && adapter_ready) begin
+                if (slv_aw_valid_i && (slv_aw_atop_i[5:4] != axi_pkg::ATOP_NONE) && adapter_ready) begin
                     // Acknowledge atomic transaction
                     slv_aw_ready_o = 1'b1;
                     // Remember request

--- a/src/axi_riscv_amos.sv
+++ b/src/axi_riscv_amos.sv
@@ -192,6 +192,7 @@ module axi_riscv_amos #(
     // States
     logic                               adapter_ready;
     logic                               transaction_collision;
+    logic                               atop_r_resp_d,  atop_r_resp_q;
     logic                               force_wf_d,     force_wf_q;
     logic                               start_wf_d,     start_wf_q;
     logic                               b_resp_valid;
@@ -266,8 +267,10 @@ module axi_riscv_amos #(
 
     always_comb begin : calc_atop_valid
         atop_valid_d = atop_valid_q;
+        atop_r_resp_d = atop_r_resp_q;
         if (adapter_ready) begin
             atop_valid_d = NONE;
+            atop_r_resp_d = 1'b0;
             if (slv_aw_valid_i && slv_aw_atop_i) begin
                 // Default is invalid request
                 atop_valid_d = INVALID;
@@ -289,6 +292,10 @@ module axi_riscv_amos #(
                 if (slv_aw_size_i > $clog2(RISCV_WORD_WIDTH/8)) begin
                     atop_valid_d = INVALID;
                 end
+                // Do we have to issue a r_resp?
+                if (slv_aw_atop_i[axi_pkg::ATOP_R_RESP]) begin
+                    atop_r_resp_d = 1'b1;
+                end
             end
         end
     end
@@ -296,8 +303,10 @@ module axi_riscv_amos #(
     always_ff @(posedge clk_i or negedge rst_ni) begin : proc_atop_valid
         if(~rst_ni) begin
             atop_valid_q <= NONE;
+            atop_r_resp_q <= 1'b0;
         end else begin
             atop_valid_q <= atop_valid_d;
+            atop_r_resp_q <= atop_r_resp_d;
         end
     end
 
@@ -878,7 +887,7 @@ module axi_riscv_amos #(
                     if (atop_valid_d == LOAD || atop_valid_d == STORE) begin
                         // Wait for R response to read data
                         r_state_d = WAIT_DATA_R;
-                    end else if (atop_valid_d == INVALID) begin
+                    end else if (atop_valid_d == INVALID && atop_r_resp_d) begin
                         // Send R response once channel is free
                         if (r_free) begin
                             // Acquire the R channel
@@ -939,7 +948,7 @@ module axi_riscv_amos #(
                     slv_r_last_o  = 1'b1;
                     slv_r_resp_o  = r_resp_q;
                     slv_r_user_o  = r_user_q;
-                    if (atop_valid_q == INVALID) begin
+                    if (atop_valid_q == INVALID && atop_r_resp_q) begin
                         slv_r_data_o = '0;
                         slv_r_resp_o = axi_pkg::RESP_SLVERR;
                         slv_r_user_o = '0;

--- a/test/golden_memory.sv
+++ b/test/golden_memory.sv
@@ -209,7 +209,22 @@ package golden_model_pkg;
 
             b_resp = axi_pkg::RESP_OKAY;
 
-            if (atop == 0) begin
+            if (atop == 6'b000111) begin
+                // LR/SC pair
+                // Wait for LR
+                read(addr, r_data, size, m_id, master);
+
+                // Check reservation
+                wait_write(addr, size, id, trans_id);
+                if (trans_id != id) begin
+                    // SC failed
+                    b_resp = axi_pkg::RESP_OKAY;
+                end else begin
+                    // Success
+                    set_memory(address, w_data, size);
+                    b_resp = axi_pkg::RESP_EXOKAY;
+                end
+            end else if (atop[5:4] == axi_pkg::ATOP_NONE) begin
                 // Wait for the write
                 wait_b(id);
                 set_memory(address, w_data, size);
@@ -262,21 +277,6 @@ package golden_model_pkg;
 
                 set_memory(address, w_data, size);
 
-            end else if (atop == 6'b000111) begin
-                // LR/SC pair
-                // Wait for LR
-                read(addr, r_data, size, m_id, master);
-
-                // Check reservation
-                wait_write(addr, size, id, trans_id);
-                if (trans_id != id) begin
-                    // SC failed
-                    b_resp = axi_pkg::RESP_OKAY;
-                end else begin
-                    // Success
-                    set_memory(address, w_data, size);
-                    b_resp = axi_pkg::RESP_EXOKAY;
-                end
             end else begin
                 b_resp = axi_pkg::RESP_SLVERR;
                 r_data = '0;

--- a/test/tb_axi_pkg.sv
+++ b/test/tb_axi_pkg.sv
@@ -117,8 +117,7 @@ package tb_axi_pkg;
                 end
                 // R response if atop
                 begin
-                    if ((atop != 0) && (atop[5:3] != {axi_pkg::ATOP_ATOMICSTORE, axi_pkg::ATOP_LITTLE_END}) &&
-                        (atop != 6'b000111)) begin // Atomic operations with read response
+                    if (atop[axi_pkg::ATOP_R_RESP]) begin // Atomic operations with read response
                         rand_delay(0,RAND_DELAY);
                         recv_r(r_beat);
                         result = r_beat.r_data;


### PR DESCRIPTION
Ensure the way unspecified/illegal ATOP opcodes are treated is aligned with how the modules in the AXI repository do it.

- Issue an R response to all ATOPs where the `axi_pkg::ATOP_R_RESP` bit is set.
- Treat all opcodes with `slv_aw_atop_i[5:4] == axi_pkg::ATOP_NONE` as non-ATOPs and simply forward them instead of issuing an error response.