### PR TITLE
axi_riscv_lrsc: Apply tool workaround to all tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](http://semver.org).
 
+## Unreleased
+
+### Changed
+- `axi_riscv_lrsc`: Always apply tool workaround, as VCS also has trouble with the syntax and
+  it is likely that other Synopsys tools suffer from the same problem.
 
 ## 0.4.0 - 2022-04-13
 

--- a/src/axi_riscv_lrsc.sv
+++ b/src/axi_riscv_lrsc.sv
@@ -493,13 +493,10 @@ module axi_riscv_lrsc #(
     );
 
     // ID Queue to track downstream W bursts and their pending B responses.
-    // Workaround for bug in Questa (at least 2018.07 is affected): Flatten the enum into a logic
-    // vector before using that type when instantiating `id_queue`.
-    `ifdef QUESTA
+    // Workaround for bug in Questa (at least 2018.07 is affected) and VCS (at least 2020.12 is
+    // affected):
+    // Flatten the enum into a logic vector before using that type when instantiating `id_queue`.
     typedef logic [$bits(b_cmd_t)-1:0] b_cmd_flat_t;
-    `else
-    typedef b_cmd_t b_cmd_flat_t;
-    `endif
     b_cmd_flat_t b_status_inp_cmd_flat, b_status_oup_cmd_flat;
     assign b_status_inp_cmd_flat = b_cmd_flat_t'(b_status_inp_cmd);
     id_queue #(


### PR DESCRIPTION
Always use a flat `b_cmd_t` for the `id_queue`, independent of the tool. Synopsys's VCS also struggles without this workaround and most likely also the other Synopsys tools. The workaround should be safe for all tools and might therefore be a better default.

This issue might be related to [the common cell's PR #138](https://github.com/pulp-platform/common_cells/pull/138). The enum type seems to be the culprit in the `id_queue`, which could potentially be fixed by always using a flat data type for the `id_queue`'s interface.