### PR TITLE
axi_riscv_lrsc_tb: Remove timeunit to improve tool compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](http://semver.org).
 
+## Unreleased
+
+### Changed
+- `axi_riscv_lrsc_tb`: Remove timeunit to improve tool compatibility
 
 ## 0.5.0 - 2022-05-03
 

--- a/test/axi_riscv_lrsc_tb.sv
+++ b/test/axi_riscv_lrsc_tb.sv
@@ -31,9 +31,6 @@ module axi_riscv_lrsc_tb #(
     parameter bit VERBOSE = 1'b0
 );
 
-    timeunit 1ns;
-    timeprecision 10ps;
-
     localparam time TCLK = 10ns;
     localparam time TA = TCLK * 1/4;
     localparam time TT = TCLK * 3/4;


### PR DESCRIPTION
Certain tools don't like the `timeunit` and `timeprecision` to be specified only in selected files. Not specifying it, unless necessary, is the easiest solution to avoid such tool issues.