### PR TITLE
`axi_riscv_atomics`: Add parameterizable cut between amo and lrsc stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/), and this 
 
 ## Unreleased
 
+### Added
+- `axi_riscv_atomics`: Add parameterizable cut between amo and lrsc stage
+
 ### Changed
 - `axi_riscv_lrsc_tb`: Remove timeunit to improve tool compatibility
 

--- a/src/axi_riscv_atomics.sv
+++ b/src/axi_riscv_atomics.sv
@@ -16,7 +16,9 @@
 //
 // Maintainer: Andreas Kurth <akurth@iis.ee.ethz.ch>
 
-module axi_riscv_atomics #(
+module axi_riscv_atomics
+  `include "axi/typedef.svh"
+#(
     /// AXI Parameters
     parameter int unsigned AXI_ADDR_WIDTH = 0,
     parameter int unsigned AXI_DATA_WIDTH = 0,
@@ -36,6 +38,8 @@ module axi_riscv_atomics #(
     // 32 for RV32; 64 for RV64, where both 32-bit (.W suffix) and 64-bit (.D suffix) AMOs are
     // supported if `aw_strb` is set correctly.
     parameter int unsigned RISCV_WORD_WIDTH = 0,
+    // Add a cut between axi_riscv_amos and axi_riscv_lrsc
+    parameter int unsigned N_AXI_CUT = 0,
     /// Derived Parameters (do NOT change manually!)
     localparam int unsigned AXI_STRB_WIDTH = AXI_DATA_WIDTH / 8
 ) (
@@ -151,6 +155,11 @@ module axi_riscv_atomics #(
     localparam longint unsigned ADDR_BEGIN  = '0;
     localparam longint unsigned ADDR_END    = {AXI_ADDR_WIDTH{1'b1}};
 
+    `AXI_TYPEDEF_ALL(int_axi, logic [AXI_ADDR_WIDTH-1:0], logic [AXI_ID_WIDTH-1:0], logic [AXI_DATA_WIDTH-1:0], logic [AXI_STRB_WIDTH-1:0], logic [AXI_USER_WIDTH-1:0])
+
+    int_axi_req_t int_axi_req, int_axi_cut_req;
+    int_axi_resp_t int_axi_rsp, int_axi_cut_rsp;
+
     logic [AXI_ADDR_WIDTH-1:0]   int_axi_aw_addr;
     logic [2:0]                  int_axi_aw_prot;
     logic [3:0]                  int_axi_aw_region;
@@ -200,6 +209,56 @@ module axi_riscv_atomics #(
     logic [AXI_USER_WIDTH-1:0]   int_axi_b_user;
     logic                        int_axi_b_ready;
     logic                        int_axi_b_valid;
+
+    logic [AXI_ADDR_WIDTH-1:0]   int_axi_cut_aw_addr;
+    logic [2:0]                  int_axi_cut_aw_prot;
+    logic [3:0]                  int_axi_cut_aw_region;
+    logic [5:0]                  int_axi_cut_aw_atop;
+    logic [7:0]                  int_axi_cut_aw_len;
+    logic [2:0]                  int_axi_cut_aw_size;
+    logic [1:0]                  int_axi_cut_aw_burst;
+    logic                        int_axi_cut_aw_lock;
+    logic [3:0]                  int_axi_cut_aw_cache;
+    logic [3:0]                  int_axi_cut_aw_qos;
+    logic [AXI_ID_WIDTH-1:0]     int_axi_cut_aw_id;
+    logic [AXI_USER_WIDTH-1:0]   int_axi_cut_aw_user;
+    logic                        int_axi_cut_aw_ready;
+    logic                        int_axi_cut_aw_valid;
+
+    logic [AXI_ADDR_WIDTH-1:0]   int_axi_cut_ar_addr;
+    logic [2:0]                  int_axi_cut_ar_prot;
+    logic [3:0]                  int_axi_cut_ar_region;
+    logic [7:0]                  int_axi_cut_ar_len;
+    logic [2:0]                  int_axi_cut_ar_size;
+    logic [1:0]                  int_axi_cut_ar_burst;
+    logic                        int_axi_cut_ar_lock;
+    logic [3:0]                  int_axi_cut_ar_cache;
+    logic [3:0]                  int_axi_cut_ar_qos;
+    logic [AXI_ID_WIDTH-1:0]     int_axi_cut_ar_id;
+    logic [AXI_USER_WIDTH-1:0]   int_axi_cut_ar_user;
+    logic                        int_axi_cut_ar_ready;
+    logic                        int_axi_cut_ar_valid;
+
+    logic [AXI_DATA_WIDTH-1:0]   int_axi_cut_w_data;
+    logic [AXI_STRB_WIDTH-1:0]   int_axi_cut_w_strb;
+    logic [AXI_USER_WIDTH-1:0]   int_axi_cut_w_user;
+    logic                        int_axi_cut_w_last;
+    logic                        int_axi_cut_w_ready;
+    logic                        int_axi_cut_w_valid;
+
+    logic [AXI_DATA_WIDTH-1:0]   int_axi_cut_r_data;
+    logic [1:0]                  int_axi_cut_r_resp;
+    logic                        int_axi_cut_r_last;
+    logic [AXI_ID_WIDTH-1:0]     int_axi_cut_r_id;
+    logic [AXI_USER_WIDTH-1:0]   int_axi_cut_r_user;
+    logic                        int_axi_cut_r_ready;
+    logic                        int_axi_cut_r_valid;
+
+    logic [1:0]                  int_axi_cut_b_resp;
+    logic [AXI_ID_WIDTH-1:0]     int_axi_cut_b_id;
+    logic [AXI_USER_WIDTH-1:0]   int_axi_cut_b_user;
+    logic                        int_axi_cut_b_ready;
+    logic                        int_axi_cut_b_valid;
 
     axi_riscv_amos #(
         .AXI_ADDR_WIDTH     (AXI_ADDR_WIDTH),
@@ -303,6 +362,118 @@ module axi_riscv_atomics #(
         .mst_b_valid_i      ( int_axi_b_valid   )
     );
 
+    assign int_axi_req.aw.addr   = int_axi_aw_addr;
+    assign int_axi_req.aw.prot   = int_axi_aw_prot;
+    assign int_axi_req.aw.region = int_axi_aw_region;
+    assign int_axi_req.aw.atop   = int_axi_aw_atop;
+    assign int_axi_req.aw.len    = int_axi_aw_len;
+    assign int_axi_req.aw.size   = int_axi_aw_size;
+    assign int_axi_req.aw.burst  = int_axi_aw_burst;
+    assign int_axi_req.aw.lock   = int_axi_aw_lock;
+    assign int_axi_req.aw.cache  = int_axi_aw_cache;
+    assign int_axi_req.aw.qos    = int_axi_aw_qos;
+    assign int_axi_req.aw.id     = int_axi_aw_id;
+    assign int_axi_req.aw.user   = int_axi_aw_user;
+    assign int_axi_aw_ready      = int_axi_rsp.aw_ready;
+    assign int_axi_req.aw_valid  = int_axi_aw_valid;
+    assign int_axi_req.ar.addr   = int_axi_ar_addr;
+    assign int_axi_req.ar.prot   = int_axi_ar_prot;
+    assign int_axi_req.ar.region = int_axi_ar_region;
+    assign int_axi_req.ar.len    = int_axi_ar_len;
+    assign int_axi_req.ar.size   = int_axi_ar_size;
+    assign int_axi_req.ar.burst  = int_axi_ar_burst;
+    assign int_axi_req.ar.lock   = int_axi_ar_lock;
+    assign int_axi_req.ar.cache  = int_axi_ar_cache;
+    assign int_axi_req.ar.qos    = int_axi_ar_qos;
+    assign int_axi_req.ar.id     = int_axi_ar_id;
+    assign int_axi_req.ar.user   = int_axi_ar_user;
+    assign int_axi_ar_ready      = int_axi_rsp.ar_ready;
+    assign int_axi_req.ar_valid  = int_axi_ar_valid;
+    assign int_axi_req.w.data    = int_axi_w_data;
+    assign int_axi_req.w.strb    = int_axi_w_strb;
+    assign int_axi_req.w.user    = int_axi_w_user;
+    assign int_axi_req.w.last    = int_axi_w_last;
+    assign int_axi_w_ready       = int_axi_rsp.w_ready;
+    assign int_axi_req.w_valid   = int_axi_w_valid;
+    assign int_axi_r_data        = int_axi_rsp.r.data;
+    assign int_axi_r_resp        = int_axi_rsp.r.resp;
+    assign int_axi_r_last        = int_axi_rsp.r.last;
+    assign int_axi_r_id          = int_axi_rsp.r.id;
+    assign int_axi_r_user        = int_axi_rsp.r.user;
+    assign int_axi_req.r_ready   = int_axi_r_ready;
+    assign int_axi_r_valid       = int_axi_rsp.r_valid;
+    assign int_axi_b_resp        = int_axi_rsp.b.resp;
+    assign int_axi_b_id          = int_axi_rsp.b.id;
+    assign int_axi_b_user        = int_axi_rsp.b.user;
+    assign int_axi_req.b_ready   = int_axi_b_ready;
+    assign int_axi_b_valid       = int_axi_rsp.b_valid;
+
+    axi_multicut #(
+        .NoCuts     ( N_AXI_CUT         ),
+        .aw_chan_t  ( int_axi_aw_chan_t ),
+        .w_chan_t   ( int_axi_w_chan_t  ),
+        .b_chan_t   ( int_axi_b_chan_t  ),
+        .ar_chan_t  ( int_axi_ar_chan_t ),
+        .r_chan_t   ( int_axi_r_chan_t  ),
+        .axi_req_t  ( int_axi_req_t     ),
+        .axi_resp_t ( int_axi_resp_t    )
+    ) i_axi_wide_in_cut (
+        .clk_i      ( clk_i           ),
+        .rst_ni     ( rst_ni          ),
+        .slv_req_i  ( int_axi_req     ),
+        .slv_resp_o ( int_axi_rsp     ),
+        .mst_req_o  ( int_axi_cut_req ),
+        .mst_resp_i ( int_axi_cut_rsp )
+    );
+
+    assign int_axi_cut_aw_addr   = int_axi_cut_req.aw.addr;
+    assign int_axi_cut_aw_prot   = int_axi_cut_req.aw.prot;
+    assign int_axi_cut_aw_region = int_axi_cut_req.aw.region;
+    assign int_axi_cut_aw_atop   = int_axi_cut_req.aw.atop;
+    assign int_axi_cut_aw_len    = int_axi_cut_req.aw.len;
+    assign int_axi_cut_aw_size   = int_axi_cut_req.aw.size;
+    assign int_axi_cut_aw_burst  = int_axi_cut_req.aw.burst;
+    assign int_axi_cut_aw_lock   = int_axi_cut_req.aw.lock;
+    assign int_axi_cut_aw_cache  = int_axi_cut_req.aw.cache;
+    assign int_axi_cut_aw_qos    = int_axi_cut_req.aw.qos;
+    assign int_axi_cut_aw_id     = int_axi_cut_req.aw.id;
+    assign int_axi_cut_aw_user   = int_axi_cut_req.aw.user;
+    assign int_axi_cut_rsp.aw_ready = int_axi_cut_aw_ready;
+    assign int_axi_cut_aw_valid  = int_axi_cut_req.aw_valid;
+    assign int_axi_cut_ar_addr   = int_axi_cut_req.ar.addr;
+    assign int_axi_cut_ar_prot   = int_axi_cut_req.ar.prot;
+    assign int_axi_cut_ar_region = int_axi_cut_req.ar.region;
+    assign int_axi_cut_ar_len    = int_axi_cut_req.ar.len;
+    assign int_axi_cut_ar_size   = int_axi_cut_req.ar.size;
+    assign int_axi_cut_ar_burst  = int_axi_cut_req.ar.burst;
+    assign int_axi_cut_ar_lock   = int_axi_cut_req.ar.lock;
+    assign int_axi_cut_ar_cache  = int_axi_cut_req.ar.cache;
+    assign int_axi_cut_ar_qos    = int_axi_cut_req.ar.qos;
+    assign int_axi_cut_ar_id     = int_axi_cut_req.ar.id;
+    assign int_axi_cut_ar_user   = int_axi_cut_req.ar.user;
+    assign int_axi_cut_rsp.ar_ready = int_axi_cut_ar_ready;
+    assign int_axi_cut_ar_valid  = int_axi_cut_req.ar_valid;
+    assign int_axi_cut_w_data    = int_axi_cut_req.w.data;
+    assign int_axi_cut_w_strb    = int_axi_cut_req.w.strb;
+    assign int_axi_cut_w_user    = int_axi_cut_req.w.user;
+    assign int_axi_cut_w_last    = int_axi_cut_req.w.last;
+    assign int_axi_cut_rsp.w_ready = int_axi_cut_w_ready;
+    assign int_axi_cut_w_valid   = int_axi_cut_req.w_valid;
+
+    assign int_axi_cut_rsp.r.data  = int_axi_cut_r_data;
+    assign int_axi_cut_rsp.r.resp  = int_axi_cut_r_resp;
+    assign int_axi_cut_rsp.r.last  = int_axi_cut_r_last;
+    assign int_axi_cut_rsp.r.id    = int_axi_cut_r_id;
+    assign int_axi_cut_rsp.r.user  = int_axi_cut_r_user;
+    assign int_axi_cut_r_ready     = int_axi_cut_req.r_ready;
+    assign int_axi_cut_rsp.r_valid = int_axi_cut_r_valid;
+
+    assign int_axi_cut_rsp.b.resp  = int_axi_cut_b_resp;
+    assign int_axi_cut_rsp.b.id    = int_axi_cut_b_id;
+    assign int_axi_cut_rsp.b.user  = int_axi_cut_b_user;
+    assign int_axi_cut_b_ready     = int_axi_cut_req.b_ready;
+    assign int_axi_cut_rsp.b_valid = int_axi_cut_b_valid;
+
     axi_riscv_lrsc #(
         .ADDR_BEGIN         (ADDR_BEGIN),
         .ADDR_END           (ADDR_END),
@@ -316,98 +487,98 @@ module axi_riscv_atomics #(
         .AXI_USER_ID_MSB    (AXI_USER_ID_MSB),
         .AXI_USER_ID_LSB    (AXI_USER_ID_LSB)
     ) i_lrsc (
-        .clk_i              ( clk_i             ),
-        .rst_ni             ( rst_ni            ),
-        .slv_aw_addr_i      ( int_axi_aw_addr   ),
-        .slv_aw_prot_i      ( int_axi_aw_prot   ),
-        .slv_aw_region_i    ( int_axi_aw_region ),
-        .slv_aw_atop_i      ( int_axi_aw_atop   ),
-        .slv_aw_len_i       ( int_axi_aw_len    ),
-        .slv_aw_size_i      ( int_axi_aw_size   ),
-        .slv_aw_burst_i     ( int_axi_aw_burst  ),
-        .slv_aw_lock_i      ( int_axi_aw_lock   ),
-        .slv_aw_cache_i     ( int_axi_aw_cache  ),
-        .slv_aw_qos_i       ( int_axi_aw_qos    ),
-        .slv_aw_id_i        ( int_axi_aw_id     ),
-        .slv_aw_user_i      ( int_axi_aw_user   ),
-        .slv_aw_ready_o     ( int_axi_aw_ready  ),
-        .slv_aw_valid_i     ( int_axi_aw_valid  ),
-        .slv_ar_addr_i      ( int_axi_ar_addr   ),
-        .slv_ar_prot_i      ( int_axi_ar_prot   ),
-        .slv_ar_region_i    ( int_axi_ar_region ),
-        .slv_ar_len_i       ( int_axi_ar_len    ),
-        .slv_ar_size_i      ( int_axi_ar_size   ),
-        .slv_ar_burst_i     ( int_axi_ar_burst  ),
-        .slv_ar_lock_i      ( int_axi_ar_lock   ),
-        .slv_ar_cache_i     ( int_axi_ar_cache  ),
-        .slv_ar_qos_i       ( int_axi_ar_qos    ),
-        .slv_ar_id_i        ( int_axi_ar_id     ),
-        .slv_ar_user_i      ( int_axi_ar_user   ),
-        .slv_ar_ready_o     ( int_axi_ar_ready  ),
-        .slv_ar_valid_i     ( int_axi_ar_valid  ),
-        .slv_w_data_i       ( int_axi_w_data    ),
-        .slv_w_strb_i       ( int_axi_w_strb    ),
-        .slv_w_user_i       ( int_axi_w_user    ),
-        .slv_w_last_i       ( int_axi_w_last    ),
-        .slv_w_ready_o      ( int_axi_w_ready   ),
-        .slv_w_valid_i      ( int_axi_w_valid   ),
-        .slv_r_data_o       ( int_axi_r_data    ),
-        .slv_r_resp_o       ( int_axi_r_resp    ),
-        .slv_r_last_o       ( int_axi_r_last    ),
-        .slv_r_id_o         ( int_axi_r_id      ),
-        .slv_r_user_o       ( int_axi_r_user    ),
-        .slv_r_ready_i      ( int_axi_r_ready   ),
-        .slv_r_valid_o      ( int_axi_r_valid   ),
-        .slv_b_resp_o       ( int_axi_b_resp    ),
-        .slv_b_id_o         ( int_axi_b_id      ),
-        .slv_b_user_o       ( int_axi_b_user    ),
-        .slv_b_ready_i      ( int_axi_b_ready   ),
-        .slv_b_valid_o      ( int_axi_b_valid   ),
-        .mst_aw_addr_o      ( mst_aw_addr_o     ),
-        .mst_aw_prot_o      ( mst_aw_prot_o     ),
-        .mst_aw_region_o    ( mst_aw_region_o   ),
-        .mst_aw_atop_o      ( mst_aw_atop_o     ),
-        .mst_aw_len_o       ( mst_aw_len_o      ),
-        .mst_aw_size_o      ( mst_aw_size_o     ),
-        .mst_aw_burst_o     ( mst_aw_burst_o    ),
-        .mst_aw_lock_o      ( mst_aw_lock_o     ),
-        .mst_aw_cache_o     ( mst_aw_cache_o    ),
-        .mst_aw_qos_o       ( mst_aw_qos_o      ),
-        .mst_aw_id_o        ( mst_aw_id_o       ),
-        .mst_aw_user_o      ( mst_aw_user_o     ),
-        .mst_aw_ready_i     ( mst_aw_ready_i    ),
-        .mst_aw_valid_o     ( mst_aw_valid_o    ),
-        .mst_ar_addr_o      ( mst_ar_addr_o     ),
-        .mst_ar_prot_o      ( mst_ar_prot_o     ),
-        .mst_ar_region_o    ( mst_ar_region_o   ),
-        .mst_ar_len_o       ( mst_ar_len_o      ),
-        .mst_ar_size_o      ( mst_ar_size_o     ),
-        .mst_ar_burst_o     ( mst_ar_burst_o    ),
-        .mst_ar_lock_o      ( mst_ar_lock_o     ),
-        .mst_ar_cache_o     ( mst_ar_cache_o    ),
-        .mst_ar_qos_o       ( mst_ar_qos_o      ),
-        .mst_ar_id_o        ( mst_ar_id_o       ),
-        .mst_ar_user_o      ( mst_ar_user_o     ),
-        .mst_ar_ready_i     ( mst_ar_ready_i    ),
-        .mst_ar_valid_o     ( mst_ar_valid_o    ),
-        .mst_w_data_o       ( mst_w_data_o      ),
-        .mst_w_strb_o       ( mst_w_strb_o      ),
-        .mst_w_user_o       ( mst_w_user_o      ),
-        .mst_w_last_o       ( mst_w_last_o      ),
-        .mst_w_ready_i      ( mst_w_ready_i     ),
-        .mst_w_valid_o      ( mst_w_valid_o     ),
-        .mst_r_data_i       ( mst_r_data_i      ),
-        .mst_r_resp_i       ( mst_r_resp_i      ),
-        .mst_r_last_i       ( mst_r_last_i      ),
-        .mst_r_id_i         ( mst_r_id_i        ),
-        .mst_r_user_i       ( mst_r_user_i      ),
-        .mst_r_ready_o      ( mst_r_ready_o     ),
-        .mst_r_valid_i      ( mst_r_valid_i     ),
-        .mst_b_resp_i       ( mst_b_resp_i      ),
-        .mst_b_id_i         ( mst_b_id_i        ),
-        .mst_b_user_i       ( mst_b_user_i      ),
-        .mst_b_ready_o      ( mst_b_ready_o     ),
-        .mst_b_valid_i      ( mst_b_valid_i     )
+        .clk_i              ( clk_i                 ),
+        .rst_ni             ( rst_ni                ),
+        .slv_aw_addr_i      ( int_axi_cut_aw_addr   ),
+        .slv_aw_prot_i      ( int_axi_cut_aw_prot   ),
+        .slv_aw_region_i    ( int_axi_cut_aw_region ),
+        .slv_aw_atop_i      ( int_axi_cut_aw_atop   ),
+        .slv_aw_len_i       ( int_axi_cut_aw_len    ),
+        .slv_aw_size_i      ( int_axi_cut_aw_size   ),
+        .slv_aw_burst_i     ( int_axi_cut_aw_burst  ),
+        .slv_aw_lock_i      ( int_axi_cut_aw_lock   ),
+        .slv_aw_cache_i     ( int_axi_cut_aw_cache  ),
+        .slv_aw_qos_i       ( int_axi_cut_aw_qos    ),
+        .slv_aw_id_i        ( int_axi_cut_aw_id     ),
+        .slv_aw_user_i      ( int_axi_cut_aw_user   ),
+        .slv_aw_ready_o     ( int_axi_cut_aw_ready  ),
+        .slv_aw_valid_i     ( int_axi_cut_aw_valid  ),
+        .slv_ar_addr_i      ( int_axi_cut_ar_addr   ),
+        .slv_ar_prot_i      ( int_axi_cut_ar_prot   ),
+        .slv_ar_region_i    ( int_axi_cut_ar_region ),
+        .slv_ar_len_i       ( int_axi_cut_ar_len    ),
+        .slv_ar_size_i      ( int_axi_cut_ar_size   ),
+        .slv_ar_burst_i     ( int_axi_cut_ar_burst  ),
+        .slv_ar_lock_i      ( int_axi_cut_ar_lock   ),
+        .slv_ar_cache_i     ( int_axi_cut_ar_cache  ),
+        .slv_ar_qos_i       ( int_axi_cut_ar_qos    ),
+        .slv_ar_id_i        ( int_axi_cut_ar_id     ),
+        .slv_ar_user_i      ( int_axi_cut_ar_user   ),
+        .slv_ar_ready_o     ( int_axi_cut_ar_ready  ),
+        .slv_ar_valid_i     ( int_axi_cut_ar_valid  ),
+        .slv_w_data_i       ( int_axi_cut_w_data    ),
+        .slv_w_strb_i       ( int_axi_cut_w_strb    ),
+        .slv_w_user_i       ( int_axi_cut_w_user    ),
+        .slv_w_last_i       ( int_axi_cut_w_last    ),
+        .slv_w_ready_o      ( int_axi_cut_w_ready   ),
+        .slv_w_valid_i      ( int_axi_cut_w_valid   ),
+        .slv_r_data_o       ( int_axi_cut_r_data    ),
+        .slv_r_resp_o       ( int_axi_cut_r_resp    ),
+        .slv_r_last_o       ( int_axi_cut_r_last    ),
+        .slv_r_id_o         ( int_axi_cut_r_id      ),
+        .slv_r_user_o       ( int_axi_cut_r_user    ),
+        .slv_r_ready_i      ( int_axi_cut_r_ready   ),
+        .slv_r_valid_o      ( int_axi_cut_r_valid   ),
+        .slv_b_resp_o       ( int_axi_cut_b_resp    ),
+        .slv_b_id_o         ( int_axi_cut_b_id      ),
+        .slv_b_user_o       ( int_axi_cut_b_user    ),
+        .slv_b_ready_i      ( int_axi_cut_b_ready   ),
+        .slv_b_valid_o      ( int_axi_cut_b_valid   ),
+        .mst_aw_addr_o      ( mst_aw_addr_o         ),
+        .mst_aw_prot_o      ( mst_aw_prot_o         ),
+        .mst_aw_region_o    ( mst_aw_region_o       ),
+        .mst_aw_atop_o      ( mst_aw_atop_o         ),
+        .mst_aw_len_o       ( mst_aw_len_o          ),
+        .mst_aw_size_o      ( mst_aw_size_o         ),
+        .mst_aw_burst_o     ( mst_aw_burst_o        ),
+        .mst_aw_lock_o      ( mst_aw_lock_o         ),
+        .mst_aw_cache_o     ( mst_aw_cache_o        ),
+        .mst_aw_qos_o       ( mst_aw_qos_o          ),
+        .mst_aw_id_o        ( mst_aw_id_o           ),
+        .mst_aw_user_o      ( mst_aw_user_o         ),
+        .mst_aw_ready_i     ( mst_aw_ready_i        ),
+        .mst_aw_valid_o     ( mst_aw_valid_o        ),
+        .mst_ar_addr_o      ( mst_ar_addr_o         ),
+        .mst_ar_prot_o      ( mst_ar_prot_o         ),
+        .mst_ar_region_o    ( mst_ar_region_o       ),
+        .mst_ar_len_o       ( mst_ar_len_o          ),
+        .mst_ar_size_o      ( mst_ar_size_o         ),
+        .mst_ar_burst_o     ( mst_ar_burst_o        ),
+        .mst_ar_lock_o      ( mst_ar_lock_o         ),
+        .mst_ar_cache_o     ( mst_ar_cache_o        ),
+        .mst_ar_qos_o       ( mst_ar_qos_o          ),
+        .mst_ar_id_o        ( mst_ar_id_o           ),
+        .mst_ar_user_o      ( mst_ar_user_o         ),
+        .mst_ar_ready_i     ( mst_ar_ready_i        ),
+        .mst_ar_valid_o     ( mst_ar_valid_o        ),
+        .mst_w_data_o       ( mst_w_data_o          ),
+        .mst_w_strb_o       ( mst_w_strb_o          ),
+        .mst_w_user_o       ( mst_w_user_o          ),
+        .mst_w_last_o       ( mst_w_last_o          ),
+        .mst_w_ready_i      ( mst_w_ready_i         ),
+        .mst_w_valid_o      ( mst_w_valid_o         ),
+        .mst_r_data_i       ( mst_r_data_i          ),
+        .mst_r_resp_i       ( mst_r_resp_i          ),
+        .mst_r_last_i       ( mst_r_last_i          ),
+        .mst_r_id_i         ( mst_r_id_i            ),
+        .mst_r_user_i       ( mst_r_user_i          ),
+        .mst_r_ready_o      ( mst_r_ready_o         ),
+        .mst_r_valid_i      ( mst_r_valid_i         ),
+        .mst_b_resp_i       ( mst_b_resp_i          ),
+        .mst_b_id_i         ( mst_b_id_i            ),
+        .mst_b_user_i       ( mst_b_user_i          ),
+        .mst_b_ready_o      ( mst_b_ready_o         ),
+        .mst_b_valid_i      ( mst_b_valid_i         )
     );
 
 endmodule

--- a/src/axi_riscv_atomics_wrap.sv
+++ b/src/axi_riscv_atomics_wrap.sv
@@ -35,6 +35,8 @@ module axi_riscv_atomics_wrap #(
     // 32 for RV32; 64 for RV64, where both 32-bit (.W suffix) and 64-bit (.D suffix) AMOs are
     // supported if `aw_strb` is set correctly.
     parameter int unsigned RISCV_WORD_WIDTH = 0,
+    // Add a cut between axi_riscv_amos and axi_riscv_lrsc
+    parameter int unsigned N_AXI_CUT = 0,
     /// Derived Parameters (do NOT change manually!)
     localparam int unsigned AXI_STRB_WIDTH = AXI_DATA_WIDTH / 8
 ) (
@@ -54,7 +56,8 @@ module axi_riscv_atomics_wrap #(
         .AXI_USER_AS_ID     (AXI_USER_AS_ID),
         .AXI_USER_ID_MSB    (AXI_USER_ID_MSB),
         .AXI_USER_ID_LSB    (AXI_USER_ID_LSB),
-        .RISCV_WORD_WIDTH   (RISCV_WORD_WIDTH)
+        .RISCV_WORD_WIDTH   (RISCV_WORD_WIDTH),
+        .N_AXI_CUT          (N_AXI_CUT)
     ) i_atomics (
         .clk_i           ( clk_i         ),
         .rst_ni          ( rst_ni        ),

--- a/test/axi_riscv_atomics_tb.sv
+++ b/test/axi_riscv_atomics_tb.sv
@@ -170,7 +170,8 @@ module automatic axi_riscv_atomics_tb;
         .AXI_USER_AS_ID     ( USER_AS_ID       ),
         .AXI_USER_ID_MSB    ( AXI_USER_WIDTH-1 ),
         .AXI_USER_ID_LSB    ( 0                ),
-        .RISCV_WORD_WIDTH   ( SYS_DATA_WIDTH   )
+        .RISCV_WORD_WIDTH   ( SYS_DATA_WIDTH   ),
+        .N_AXI_CUT          ( 1                )
     ) i_axi_atomic_adapter (
         .clk_i    ( clk     ),
         .rst_ni   ( rst_n   ),


### PR DESCRIPTION
Add a parametrizable number of cuts between the AMO and LR/SC stage to match the timing of the desired design.