### PR TITLE
axi_riscv_lrsc: Set reservation granularity to AXI DW

### DIFF
--- a/src/axi_riscv_atomics.sv
+++ b/src/axi_riscv_atomics.sv
@@ -34,6 +34,8 @@ module axi_riscv_atomics
     parameter int unsigned AXI_USER_ID_MSB = 0,
     // LSB of the ID in the user signal
     parameter int unsigned AXI_USER_ID_LSB = 0,
+    // LSB of the AXI address for reservations (determines the reservation granularity)
+    parameter int unsigned AXI_ADDR_LSB = $clog2(AXI_DATA_WIDTH/8),
     // Word width of the widest RISC-V processor that can issue requests to this module.
     // 32 for RV32; 64 for RV64, where both 32-bit (.W suffix) and 64-bit (.D suffix) AMOs are
     // supported if `aw_strb` is set correctly.
@@ -485,7 +487,8 @@ module axi_riscv_atomics
         .AXI_MAX_WRITE_TXNS (AXI_MAX_WRITE_TXNS),
         .AXI_USER_AS_ID     (AXI_USER_AS_ID),
         .AXI_USER_ID_MSB    (AXI_USER_ID_MSB),
-        .AXI_USER_ID_LSB    (AXI_USER_ID_LSB)
+        .AXI_USER_ID_LSB    (AXI_USER_ID_LSB),
+        .AXI_ADDR_LSB       (AXI_ADDR_LSB)
     ) i_lrsc (
         .clk_i              ( clk_i                 ),
         .rst_ni             ( rst_ni                ),

--- a/src/axi_riscv_atomics_structs.sv
+++ b/src/axi_riscv_atomics_structs.sv
@@ -30,6 +30,7 @@ module axi_riscv_atomics_structs #(
   parameter int unsigned  AxiUserIdLsb    = 0,
   parameter int unsigned  RiscvWordWidth  = 0,
   parameter int unsigned  NAxiCuts        = 0,
+  parameter int unsigned  AxiAddrLSB      = $clog2(AxiDataWidth/8),
   parameter type          axi_req_t       = logic,
   parameter type          axi_rsp_t       = logic
 ) (
@@ -71,6 +72,7 @@ module axi_riscv_atomics_structs #(
     .AXI_USER_AS_ID     ( AxiUserAsId     ),
     .AXI_USER_ID_MSB    ( AxiUserIdMsb    ),
     .AXI_USER_ID_LSB    ( AxiUserIdLsb    ),
+    .AXI_ADDR_LSB       ( AxiAddrLSB      ),
     .RISCV_WORD_WIDTH   ( RiscvWordWidth  ),
     .N_AXI_CUT          ( NAxiCuts        )
   ) i_axi_riscv_atomics_wrap (

--- a/src/axi_riscv_atomics_wrap.sv
+++ b/src/axi_riscv_atomics_wrap.sv
@@ -31,6 +31,8 @@ module axi_riscv_atomics_wrap #(
     parameter int unsigned AXI_USER_ID_MSB = 0,
     // LSB of the ID in the user signal
     parameter int unsigned AXI_USER_ID_LSB = 0,
+    // LSB of the AXI address for reservations (determines the reservation granularity)
+    parameter int unsigned AXI_ADDR_LSB = $clog2(AXI_DATA_WIDTH/8),
     // Word width of the widest RISC-V processor that can issue requests to this module.
     // 32 for RV32; 64 for RV64, where both 32-bit (.W suffix) and 64-bit (.D suffix) AMOs are
     // supported if `aw_strb` is set correctly.
@@ -56,6 +58,7 @@ module axi_riscv_atomics_wrap #(
         .AXI_USER_AS_ID     (AXI_USER_AS_ID),
         .AXI_USER_ID_MSB    (AXI_USER_ID_MSB),
         .AXI_USER_ID_LSB    (AXI_USER_ID_LSB),
+        .AXI_ADDR_LSB       (AXI_ADDR_LSB),
         .RISCV_WORD_WIDTH   (RISCV_WORD_WIDTH),
         .N_AXI_CUT          (N_AXI_CUT)
     ) i_atomics (

--- a/src/axi_riscv_lrsc_wrap.sv
+++ b/src/axi_riscv_lrsc_wrap.sv
@@ -29,6 +29,7 @@ module axi_riscv_lrsc_wrap #(
     parameter bit AXI_USER_AS_ID = 1'b0,           // Use the AXI User signal instead of the AXI ID to track reservations
     parameter int unsigned AXI_USER_ID_MSB = 0,    // MSB of the ID in the user signal
     parameter int unsigned AXI_USER_ID_LSB = 0,    // LSB of the ID in the user signal
+    parameter int unsigned AXI_ADDR_LSB = $clog2(AXI_DATA_WIDTH/8), // log2 of granularity for reservations (ignored LSBs)
     /// Enable debug prints (not synthesizable).
     parameter bit DEBUG = 1'b0,
     /// Derived Parameters (do NOT change manually!)
@@ -52,6 +53,7 @@ module axi_riscv_lrsc_wrap #(
         .AXI_USER_AS_ID         (AXI_USER_AS_ID),
         .AXI_USER_ID_MSB        (AXI_USER_ID_MSB),
         .AXI_USER_ID_LSB        (AXI_USER_ID_LSB),
+        .AXI_ADDR_LSB           (AXI_ADDR_LSB),
         .DEBUG                  (DEBUG)
     ) i_lrsc (
         .clk_i           ( clk_i         ),

--- a/test/axi_riscv_lrsc_tb.sv
+++ b/test/axi_riscv_lrsc_tb.sv
@@ -21,6 +21,7 @@ module axi_riscv_lrsc_tb #(
     parameter int unsigned ADDR_END = 8'hAF,
     parameter int unsigned AXI_MAX_READ_TXNS = 16,
     parameter int unsigned AXI_MAX_WRITE_TXNS = 16,
+    parameter int unsigned AXI_ADDR_LSB = 3,
     parameter bit DEBUG = 1'b0,
     // TB Parameters
     parameter int unsigned REQ_MIN_WAIT_CYCLES = 0,
@@ -98,6 +99,7 @@ module axi_riscv_lrsc_tb #(
         .AXI_USER_WIDTH         (AXI_USER_WIDTH),
         .AXI_MAX_READ_TXNS      (AXI_MAX_READ_TXNS),
         .AXI_MAX_WRITE_TXNS     (AXI_MAX_WRITE_TXNS),
+        .AXI_ADDR_LSB           (AXI_ADDR_LSB),
         .DEBUG                  (DEBUG)
     ) dut (
         .clk_i  (clk),


### PR DESCRIPTION
... and parametrise it. The reason is that an AXI beat can write up to `AXI_DATA_WIDTH` bits and should therefore clear any reservations in an `AXI_DATA_WIDTH` range. We could also set the default value for `AXI_ADDR_LSB` to `2` to keep this behaviorally equivalent.