### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -1,0 +1,24 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Based on https://github.com/pulp-platform/pulp-actions/tree/main/gitlab-ci#action-usage
+
+# Author: Nils Wistoff <nwistoff@iis.ee.ethz.ch>
+
+name: gitlab-ci
+
+on: [ push, pull_request, workflow_dispatch ]
+
+jobs:
+  gitlab-ci:
+    runs-on: ubuntu-latest
+    # Skip on forks or pull requests from forks due to missing secrets.
+    if: github.repository == 'pulp-platform/axi_riscv_atomics' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    steps:
+      - name: Check Gitlab CI
+        uses: pulp-platform/pulp-actions/gitlab-ci@v2
+        with:
+          domain: iis-git.ee.ethz.ch
+          repo: github-mirror/axi_riscv_atomics
+          token: ${{ secrets.GITLAB_TOKEN }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,36 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Author: Nils Wistoff <nwistoff@iis.ee.ethz.ch>
+
+variables:
+  VSIM: questa-2022.3 vsim -64
+  VLIB: questa-2022.3 vlib
+  VMAP: questa-2022.3 vmap
+  VCOM: questa-2022.3 vcom -64
+  VLOG: questa-2022.3 vlog -64
+  VOPT: questa-2022.3 vopt -64
+
+stages:
+  - test
+
+.test-tpl:
+  stage: test
+  needs:
+  variables:
+    TOPLEVEL: ""
+  timeout: 20min
+  script:
+    - bender script vsim -t test > compile.tcl
+    - $VSIM -c -quiet -do 'source compile.tcl; quit'
+    - $VSIM -c $TOPLEVEL -do "run -all"
+    - (! grep -n "Error:" transcript)
+
+tests:
+  extends: .test-tpl
+  parallel:
+    matrix:
+      - TOPLEVEL:
+          - axi_riscv_atomics_tb
+          - axi_riscv_lrsc_tb


### PR DESCRIPTION
Add a CI which
- checks linting,
- runs the testbenches in `test` on the internal gitlab mirror and checks the results.

Requires a bit of [preparation](https://github.com/pulp-platform/pulp-actions/tree/main/gitlab-ci#preparation) to work.