### PR TITLE
Fix Non-Blocking Assignment in LRSC FF

### DIFF
--- a/src/axi_riscv_lrsc.sv
+++ b/src/axi_riscv_lrsc.sv
@@ -1036,21 +1036,21 @@ module axi_riscv_lrsc #(
     // Registers
     always_ff @(posedge clk_i, negedge rst_ni) begin
         if (~rst_ni) begin
-            ar_state_q = AR_IDLE;
-            aw_state_q = AW_IDLE;
-            b_state_q  = B_NORMAL;
-            clr_addr_q = '0;
-            clr_len_q  = '0;
-            clr_id_q   = '0;
-            aw_wait_q  = '0;
+            ar_state_q <= AR_IDLE;
+            aw_state_q <= AW_IDLE;
+            b_state_q  <= B_NORMAL;
+            clr_addr_q <= '0;
+            clr_len_q  <= '0;
+            clr_id_q   <= '0;
+            aw_wait_q  <= '0;
         end else begin
-            ar_state_q = ar_state_d;
-            aw_state_q = aw_state_d;
-            b_state_q  = b_state_d;
-            clr_addr_q = clr_addr_d;
-            clr_len_q  = clr_len_d;
-            clr_id_q   = clr_id_d;
-            aw_wait_q  = aw_wait_d;
+            ar_state_q <= ar_state_d;
+            aw_state_q <= aw_state_d;
+            b_state_q  <= b_state_d;
+            clr_addr_q <= clr_addr_d;
+            clr_len_q  <= clr_len_d;
+            clr_id_q   <= clr_id_d;
+            aw_wait_q  <= aw_wait_d;
         end
     end
 


### PR DESCRIPTION
The blocking assignment causes the `clr_len_q` to take an incorrect value during consecutive  AXI bursts (value zero from the proceeding burst instead of the actual value). This leads to an underflow of the length value and the counter has to decrement until it reaches one and the `AW_BURST` state can finally be left. This issue was discovered under Verilator. The fix results in a 10x simulation speed improvement.