### PR TITLE
Make the `CUT_OUP_POP_INP_GNT` ID queue parameter user visible and bump common cells

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -4,7 +4,7 @@ package:
 
 dependencies:
   axi: { git: "https://github.com/pulp-platform/axi.git", version: 0.35.1 }
-  common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.11.0 }
+  common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.37.0 }
   common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.2.1 }
 
 sources:

--- a/src/axi_riscv_atomics.sv
+++ b/src/axi_riscv_atomics.sv
@@ -44,6 +44,8 @@ module axi_riscv_atomics
     parameter int unsigned N_AXI_CUT = 0,
     /// Enable full bandwidth in LRSC ID queues
     parameter bit FULL_BANDWIDTH = 1'b1,
+    /// Cut combinational path between input and output in LRSC ID queues with full bandwidth
+    parameter bit CUT_OUP_POP_INP_GNT = 1'b0,
     /// Derived Parameters (do NOT change manually!)
     localparam int unsigned AXI_STRB_WIDTH = AXI_DATA_WIDTH / 8
 ) (
@@ -479,19 +481,20 @@ module axi_riscv_atomics
     assign int_axi_cut_rsp.b_valid = int_axi_cut_b_valid;
 
     axi_riscv_lrsc #(
-        .ADDR_BEGIN         (ADDR_BEGIN),
-        .ADDR_END           (ADDR_END),
-        .AXI_ADDR_WIDTH     (AXI_ADDR_WIDTH),
-        .AXI_DATA_WIDTH     (AXI_DATA_WIDTH),
-        .AXI_ID_WIDTH       (AXI_ID_WIDTH),
-        .AXI_USER_WIDTH     (AXI_USER_WIDTH),
-        .AXI_MAX_READ_TXNS  (AXI_MAX_READ_TXNS),
-        .AXI_MAX_WRITE_TXNS (AXI_MAX_WRITE_TXNS),
-        .AXI_USER_AS_ID     (AXI_USER_AS_ID),
-        .AXI_USER_ID_MSB    (AXI_USER_ID_MSB),
-        .AXI_USER_ID_LSB    (AXI_USER_ID_LSB),
-        .AXI_ADDR_LSB       (AXI_ADDR_LSB),
-        .FULL_BANDWIDTH     (FULL_BANDWIDTH)
+        .ADDR_BEGIN          (ADDR_BEGIN),
+        .ADDR_END            (ADDR_END),
+        .AXI_ADDR_WIDTH      (AXI_ADDR_WIDTH),
+        .AXI_DATA_WIDTH      (AXI_DATA_WIDTH),
+        .AXI_ID_WIDTH        (AXI_ID_WIDTH),
+        .AXI_USER_WIDTH      (AXI_USER_WIDTH),
+        .AXI_MAX_READ_TXNS   (AXI_MAX_READ_TXNS),
+        .AXI_MAX_WRITE_TXNS  (AXI_MAX_WRITE_TXNS),
+        .AXI_USER_AS_ID      (AXI_USER_AS_ID),
+        .AXI_USER_ID_MSB     (AXI_USER_ID_MSB),
+        .AXI_USER_ID_LSB     (AXI_USER_ID_LSB),
+        .AXI_ADDR_LSB        (AXI_ADDR_LSB),
+        .FULL_BANDWIDTH      (FULL_BANDWIDTH),
+        .CUT_OUP_POP_INP_GNT (CUT_OUP_POP_INP_GNT)
     ) i_lrsc (
         .clk_i              ( clk_i                 ),
         .rst_ni             ( rst_ni                ),

--- a/src/axi_riscv_atomics_structs.sv
+++ b/src/axi_riscv_atomics_structs.sv
@@ -32,6 +32,7 @@ module axi_riscv_atomics_structs #(
   parameter int unsigned  NAxiCuts        = 0,
   parameter int unsigned  AxiAddrLSB      = $clog2(AxiDataWidth/8),
   parameter bit           FullBandwidth   = 1,
+  parameter bit           CutOupPopInpGnt = 0,
   parameter type          axi_req_t       = logic,
   parameter type          axi_rsp_t       = logic
 ) (
@@ -64,19 +65,20 @@ module axi_riscv_atomics_structs #(
   `AXI_ASSIGN_FROM_RESP(mst, axi_mst_rsp_i)
 
   axi_riscv_atomics_wrap #(
-    .AXI_ADDR_WIDTH     ( AxiAddrWidth    ),
-    .AXI_DATA_WIDTH     ( AxiDataWidth    ),
-    .AXI_ID_WIDTH       ( AxiIdWidth      ),
-    .AXI_USER_WIDTH     ( AxiUserWidth    ),
-    .AXI_MAX_READ_TXNS  ( AxiMaxReadTxns  ),
-    .AXI_MAX_WRITE_TXNS ( AxiMaxWriteTxns ),
-    .AXI_USER_AS_ID     ( AxiUserAsId     ),
-    .AXI_USER_ID_MSB    ( AxiUserIdMsb    ),
-    .AXI_USER_ID_LSB    ( AxiUserIdLsb    ),
-    .AXI_ADDR_LSB       ( AxiAddrLSB      ),
-    .RISCV_WORD_WIDTH   ( RiscvWordWidth  ),
-    .N_AXI_CUT          ( NAxiCuts        ),
-    .FULL_BANDWIDTH     ( FullBandwidth   )
+    .AXI_ADDR_WIDTH      ( AxiAddrWidth    ),
+    .AXI_DATA_WIDTH      ( AxiDataWidth    ),
+    .AXI_ID_WIDTH        ( AxiIdWidth      ),
+    .AXI_USER_WIDTH      ( AxiUserWidth    ),
+    .AXI_MAX_READ_TXNS   ( AxiMaxReadTxns  ),
+    .AXI_MAX_WRITE_TXNS  ( AxiMaxWriteTxns ),
+    .AXI_USER_AS_ID      ( AxiUserAsId     ),
+    .AXI_USER_ID_MSB     ( AxiUserIdMsb    ),
+    .AXI_USER_ID_LSB     ( AxiUserIdLsb    ),
+    .AXI_ADDR_LSB        ( AxiAddrLSB      ),
+    .RISCV_WORD_WIDTH    ( RiscvWordWidth  ),
+    .N_AXI_CUT           ( NAxiCuts        ),
+    .FULL_BANDWIDTH      ( FullBandwidth   ),
+    .CUT_OUP_POP_INP_GNT ( CutOupPopInpGnt )
   ) i_axi_riscv_atomics_wrap (
     .clk_i,
     .rst_ni,

--- a/src/axi_riscv_atomics_wrap.sv
+++ b/src/axi_riscv_atomics_wrap.sv
@@ -41,6 +41,8 @@ module axi_riscv_atomics_wrap #(
     parameter int unsigned N_AXI_CUT = 0,
     /// Enable full bandwidth in LRSC ID queues
     parameter bit FULL_BANDWIDTH = 1'b1,
+    /// Cut combinational path between input and output in LRSC ID queues with full bandwidth
+    parameter bit CUT_OUP_POP_INP_GNT = 1'b0,
     /// Derived Parameters (do NOT change manually!)
     localparam int unsigned AXI_STRB_WIDTH = AXI_DATA_WIDTH / 8
 ) (
@@ -51,19 +53,20 @@ module axi_riscv_atomics_wrap #(
 );
 
     axi_riscv_atomics #(
-        .AXI_ADDR_WIDTH     (AXI_ADDR_WIDTH),
-        .AXI_DATA_WIDTH     (AXI_DATA_WIDTH),
-        .AXI_ID_WIDTH       (AXI_ID_WIDTH),
-        .AXI_USER_WIDTH     (AXI_USER_WIDTH),
-        .AXI_MAX_READ_TXNS  (AXI_MAX_READ_TXNS),
-        .AXI_MAX_WRITE_TXNS (AXI_MAX_WRITE_TXNS),
-        .AXI_USER_AS_ID     (AXI_USER_AS_ID),
-        .AXI_USER_ID_MSB    (AXI_USER_ID_MSB),
-        .AXI_USER_ID_LSB    (AXI_USER_ID_LSB),
-        .AXI_ADDR_LSB       (AXI_ADDR_LSB),
-        .RISCV_WORD_WIDTH   (RISCV_WORD_WIDTH),
-        .N_AXI_CUT          (N_AXI_CUT),
-        .FULL_BANDWIDTH     (FULL_BANDWIDTH)
+        .AXI_ADDR_WIDTH      (AXI_ADDR_WIDTH),
+        .AXI_DATA_WIDTH      (AXI_DATA_WIDTH),
+        .AXI_ID_WIDTH        (AXI_ID_WIDTH),
+        .AXI_USER_WIDTH      (AXI_USER_WIDTH),
+        .AXI_MAX_READ_TXNS   (AXI_MAX_READ_TXNS),
+        .AXI_MAX_WRITE_TXNS  (AXI_MAX_WRITE_TXNS),
+        .AXI_USER_AS_ID      (AXI_USER_AS_ID),
+        .AXI_USER_ID_MSB     (AXI_USER_ID_MSB),
+        .AXI_USER_ID_LSB     (AXI_USER_ID_LSB),
+        .AXI_ADDR_LSB        (AXI_ADDR_LSB),
+        .RISCV_WORD_WIDTH    (RISCV_WORD_WIDTH),
+        .N_AXI_CUT           (N_AXI_CUT),
+        .FULL_BANDWIDTH      (FULL_BANDWIDTH),
+        .CUT_OUP_POP_INP_GNT (CUT_OUP_POP_INP_GNT)
     ) i_atomics (
         .clk_i           ( clk_i         ),
         .rst_ni          ( rst_ni        ),

--- a/src/axi_riscv_lrsc.sv
+++ b/src/axi_riscv_lrsc.sv
@@ -46,6 +46,8 @@ module axi_riscv_lrsc #(
     parameter bit DEBUG = 1'b0,
     /// Enable full bandwidth in ID queues
     parameter bit FULL_BANDWIDTH = 1'b1,
+    /// Cut combinational path between input and output in ID queues with full bandwidth
+    parameter bit CUT_OUP_POP_INP_GNT = 1'b0,
     /// Derived Parameters (do NOT change manually!)
     localparam int unsigned AXI_STRB_WIDTH = AXI_DATA_WIDTH / 8
 ) (
@@ -330,10 +332,11 @@ module axi_riscv_lrsc #(
 
     // IQ Queue to track in-flight reads
     id_queue #(
-        .ID_WIDTH   (AXI_ID_WIDTH),
-        .CAPACITY   (AXI_MAX_READ_TXNS),
-        .data_t     (r_flight_t),
-        .FULL_BW    (FULL_BANDWIDTH)
+        .ID_WIDTH            (AXI_ID_WIDTH),
+        .CAPACITY            (AXI_MAX_READ_TXNS),
+        .data_t              (r_flight_t),
+        .FULL_BW             (FULL_BANDWIDTH),
+        .CUT_OUP_POP_INP_GNT (CUT_OUP_POP_INP_GNT)
     ) i_read_in_flight_queue (
         .clk_i              (clk_i),
         .rst_ni             (rst_ni),
@@ -514,10 +517,11 @@ module axi_riscv_lrsc #(
     b_cmd_flat_t b_status_inp_cmd_flat, b_status_oup_cmd_flat;
     assign b_status_inp_cmd_flat = b_cmd_flat_t'(b_status_inp_cmd);
     id_queue #(
-        .ID_WIDTH   (AXI_ID_WIDTH),
-        .CAPACITY   (AXI_MAX_WRITE_TXNS),
-        .data_t     (b_cmd_flat_t),
-        .FULL_BW    (FULL_BANDWIDTH)
+        .ID_WIDTH            (AXI_ID_WIDTH),
+        .CAPACITY            (AXI_MAX_WRITE_TXNS),
+        .data_t              (b_cmd_flat_t),
+        .FULL_BW             (FULL_BANDWIDTH),
+        .CUT_OUP_POP_INP_GNT (CUT_OUP_POP_INP_GNT)
     ) i_b_status_queue (
         .clk_i              (clk_i),
         .rst_ni             (rst_ni),
@@ -541,10 +545,11 @@ module axi_riscv_lrsc #(
 
     // ID Queue to track in-flight writes.
     id_queue #(
-        .ID_WIDTH   (AXI_ID_WIDTH),
-        .CAPACITY   (AXI_MAX_WRITE_TXNS),
-        .data_t     (w_flight_t),
-        .FULL_BW    (FULL_BANDWIDTH)
+        .ID_WIDTH            (AXI_ID_WIDTH),
+        .CAPACITY            (AXI_MAX_WRITE_TXNS),
+        .data_t              (w_flight_t),
+        .FULL_BW             (FULL_BANDWIDTH),
+        .CUT_OUP_POP_INP_GNT (CUT_OUP_POP_INP_GNT)
     ) i_write_in_flight_queue (
         .clk_i              (clk_i),
         .rst_ni             (rst_ni),

--- a/src/axi_riscv_lrsc_wrap.sv
+++ b/src/axi_riscv_lrsc_wrap.sv
@@ -32,6 +32,8 @@ module axi_riscv_lrsc_wrap #(
     parameter int unsigned AXI_ADDR_LSB = $clog2(AXI_DATA_WIDTH/8), // log2 of granularity for reservations (ignored LSBs)
     /// Enable full bandwidth in LRSC ID queues
     parameter bit FULL_BANDWIDTH = 1'b1,
+    /// Cut combinational path between input and output in LRSC ID queues with full bandwidth
+    parameter bit CUT_OUP_POP_INP_GNT = 1'b0,
     /// Enable debug prints (not synthesizable).
     parameter bit DEBUG = 1'b0,
     /// Derived Parameters (do NOT change manually!)
@@ -57,6 +59,7 @@ module axi_riscv_lrsc_wrap #(
         .AXI_USER_ID_LSB        (AXI_USER_ID_LSB),
         .AXI_ADDR_LSB           (AXI_ADDR_LSB),
         .FULL_BANDWIDTH         (FULL_BANDWIDTH),
+        .CUT_OUP_POP_INP_GNT    (CUT_OUP_POP_INP_GNT),
         .DEBUG                  (DEBUG)
     ) i_lrsc (
         .clk_i           ( clk_i         ),


### PR DESCRIPTION
The use of `FULL_BANDWIDTH=1` ID queues paired with `CUT_OUP_POP_INP_GNT=0` (default value) might lead to combinational loops with downstream IPs. Cutting the combinational path between input and output solves the problem.

This PR extends https://github.com/pulp-platform/axi_riscv_atomics/pull/34 to make the `CUT_OUP_POP_INP_GNT` parameter user visible and bumps the `common_cells` dependency.

Would it be better to allow more granularity, i.e. allowing for individual ID queues tuning?