### PR TITLE
Add support for limited number of reservations

### DIFF
--- a/src/axi_res_tbl.sv
+++ b/src/axi_res_tbl.sv
@@ -31,7 +31,7 @@ module axi_res_tbl #(
 
     localparam integer N_IDS = 2**AXI_ID_WIDTH;
 
-    if (N_IDS == NUM_RESERVATIONS) begin : gen_standard_table
+    if (N_IDS <= NUM_RESERVATIONS) begin : gen_standard_table
         // Declarations of Signals and Types
         logic [N_IDS-1:0][AXI_ADDR_WIDTH-1:0]   tbl_d,                      tbl_q;
         logic                                   clr,
@@ -172,8 +172,6 @@ module axi_res_tbl #(
             else $fatal(1, "AXI_ADDR_WIDTH must be greater than 0!");
         assert (AXI_ID_WIDTH > 0)
             else $fatal(1, "AXI_ID_WIDTH must be greater than 0!");
-        assert (NUM_RESERVATIONS <= N_IDS)
-            else $fatal(1, "NUM_RESERVATIONS must be less than or equal to N_IDS!");
     end
 `endif
 // pragma translate_on

--- a/src/axi_res_tbl.sv
+++ b/src/axi_res_tbl.sv
@@ -84,6 +84,7 @@ module axi_res_tbl #(
         logic [NUM_RESERVATIONS-1:0] plru_used, plru_evict_oh;
         logic [cf_math_pkg::idx_width(NUM_RESERVATIONS)-1:0] plru_evict;
         logic [NUM_RESERVATIONS-1:0][AXI_ID_WIDTH-1:0] tbl_id_d, tbl_id_q;
+        logic [NUM_RESERVATIONS-1:0] field_in_use_d, field_in_use_q;
 
         plru_tree #(
             .ENTRIES(NUM_RESERVATIONS)
@@ -105,26 +106,42 @@ module axi_res_tbl #(
             tbl_d = tbl_q;
             tbl_id_d = tbl_id_q;
             matching_set = 1'b0;
+            field_in_use_d = field_in_use_q;
             if (set) begin
+                // First reuse existing entry for ID
                 for (int i = 0; i < NUM_RESERVATIONS; ++i) begin
                     if (set_id_i == tbl_id_q[i]) begin
                         tbl_d[i] = set_addr_i;
                         plru_used[i] = 1'b1;
                         matching_set = 1'b1;
+                        field_in_use_d[i] = 1'b1;
                         break;
                     end
                 end
+                // Then check for unused entries
+                for (int i = 0; i < NUM_RESERVATIONS; ++i) begin
+                    if (!field_in_use_q[i] && !matching_set) begin
+                        tbl_d[i] = set_addr_i;
+                        plru_used[i] = 1'b1;
+                        matching_set = 1'b1;
+                        field_in_use_d[i] = 1'b1;
+                        break;
+                    end
+                end
+                // Finally evict the least recently used entry
                 for (int i = 0; i < NUM_RESERVATIONS; ++i) begin
                     if (i == plru_evict && !matching_set) begin
                         tbl_d[i] = set_addr_i;
                         tbl_id_d[i] = set_id_i;
                         plru_used[i] = 1'b1;
+                        field_in_use_d[i] = 1'b1;
                     end
                 end
             end else if (clr) begin
                 for (int i = 0; i < NUM_RESERVATIONS; ++i) begin
                     if (tbl_q[i] == check_clr_addr_i) begin
                         tbl_d[i] = '0;
+                        field_in_use_d[i] = 1'b0;
                     end
                 end
             end
@@ -141,7 +158,9 @@ module axi_res_tbl #(
 
             if (check_clr_req_i) begin
                 for (int i = 0; i < NUM_RESERVATIONS; i++) begin
-                    match |= (tbl_q[i] == check_clr_addr_i) && (tbl_id_q[i] == check_id_i);
+                    match |= (tbl_q[i] == check_clr_addr_i) &&
+                             (tbl_id_q[i] == check_id_i) &&
+                             field_in_use_q[i];
                 end
                 check_clr_gnt_o = 1'b1;
                 check_res_o     = match;
@@ -157,9 +176,11 @@ module axi_res_tbl #(
             if (~rst_ni) begin
                 tbl_q   <= '0;
                 tbl_id_q <= '0;
+                field_in_use_q <= '0;
             end else begin
                 tbl_q   <= tbl_d;
                 tbl_id_q <= tbl_id_d;
+                field_in_use_q <= field_in_use_d;
             end
         end
     end

--- a/src/axi_res_tbl.sv
+++ b/src/axi_res_tbl.sv
@@ -106,7 +106,7 @@ module axi_res_tbl #(
             tbl_id_d = tbl_id_q;
             matching_set = 1'b0;
             if (set) begin
-                for (genvar i = 0; i < NUM_RESERVATIONS; ++i) begin
+                for (int i = 0; i < NUM_RESERVATIONS; ++i) begin
                     if (set_id_i == tbl_id_q[i]) begin
                         tbl_d[i] = set_addr_i;
                         plru_used[i] = 1'b1;
@@ -114,7 +114,7 @@ module axi_res_tbl #(
                         break;
                     end
                 end
-                for (genvar i = 0; i < NUM_RESERVATIONS; ++i) begin
+                for (int i = 0; i < NUM_RESERVATIONS; ++i) begin
                     if (i == plru_evict && !matching_set) begin
                         tbl_d[i] = set_addr_i;
                         tbl_id_d[i] = set_id_i;
@@ -122,7 +122,7 @@ module axi_res_tbl #(
                     end
                 end
             end else if (clr) begin
-                for (genvar i = 0; i < NUM_RESERVATIONS; ++i) begin
+                for (int i = 0; i < NUM_RESERVATIONS; ++i) begin
                     if (tbl_q[i] == check_clr_addr_i) begin
                         tbl_d[i] = '0;
                     end

--- a/src/axi_res_tbl.sv
+++ b/src/axi_res_tbl.sv
@@ -12,7 +12,8 @@
 // AXI Reservation Table
 module axi_res_tbl #(
     parameter int unsigned AXI_ADDR_WIDTH = 0,
-    parameter int unsigned AXI_ID_WIDTH = 0
+    parameter int unsigned AXI_ID_WIDTH = 0,
+    parameter int unsigned NUM_RESERVATIONS = 2**AXI_ID_WIDTH
 ) (
     input  logic                        clk_i,
     input  logic                        rst_ni,
@@ -30,49 +31,136 @@ module axi_res_tbl #(
 
     localparam integer N_IDS = 2**AXI_ID_WIDTH;
 
-    // Declarations of Signals and Types
-    logic [N_IDS-1:0][AXI_ADDR_WIDTH-1:0]   tbl_d,                      tbl_q;
-    logic                                   clr,
-                                            set,
-                                            match;
+    if (N_IDS == NUM_RESERVATIONS) begin : gen_standard_table
+        // Declarations of Signals and Types
+        logic [N_IDS-1:0][AXI_ADDR_WIDTH-1:0]   tbl_d,                      tbl_q;
+        logic                                   clr,
+                                                set,
+                                                match;
 
-    assign match = (tbl_q[check_id_i] == check_clr_addr_i);
+        assign match = (tbl_q[check_id_i] == check_clr_addr_i);
 
-    generate for (genvar i = 0; i < N_IDS; ++i) begin: gen_tbl
-        always_comb begin
-            tbl_d[i] = tbl_q[i];
-            if (set && i == set_id_i) begin
-                tbl_d[i] = set_addr_i;
-            end else if (clr && tbl_q[i] == check_clr_addr_i) begin
-                tbl_d[i] = '0;
+        for (genvar i = 0; i < N_IDS; ++i) begin: gen_tbl
+            always_comb begin
+                tbl_d[i] = tbl_q[i];
+                if (set && i == set_id_i) begin
+                    tbl_d[i] = set_addr_i;
+                end else if (clr && tbl_q[i] == check_clr_addr_i) begin
+                    tbl_d[i] = '0;
+                end
             end
         end
-    end endgenerate
 
-    // Table-Managing Logic
-    always_comb begin
-        clr             = 1'b0;
-        set             = 1'b0;
-        set_gnt_o       = 1'b0;
-        check_res_o     = 1'b0;
-        check_clr_gnt_o = 1'b0;
+        // Table-Managing Logic
+        always_comb begin
+            clr             = 1'b0;
+            set             = 1'b0;
+            set_gnt_o       = 1'b0;
+            check_res_o     = 1'b0;
+            check_clr_gnt_o = 1'b0;
 
-        if (check_clr_req_i) begin
-            check_clr_gnt_o = 1'b1;
-            check_res_o     = match;
-            clr             = !(check_clr_excl_i && !match);
-        end else if (set_req_i) begin
-            set         = 1'b1;
-            set_gnt_o   = 1'b1;
+            if (check_clr_req_i) begin
+                check_clr_gnt_o = 1'b1;
+                check_res_o     = match;
+                clr             = !(check_clr_excl_i && !match);
+            end else if (set_req_i) begin
+                set         = 1'b1;
+                set_gnt_o   = 1'b1;
+            end
         end
-    end
 
-    // Registers
-    always_ff @(posedge clk_i, negedge rst_ni) begin
-        if (~rst_ni) begin
-            tbl_q   <= '0;
-        end else begin
-            tbl_q   <= tbl_d;
+        // Registers
+        always_ff @(posedge clk_i, negedge rst_ni) begin
+            if (~rst_ni) begin
+                tbl_q   <= '0;
+            end else begin
+                tbl_q   <= tbl_d;
+            end
+        end
+    end else begin : gen_prlu_table
+        // Declarations of Signals and Types
+        logic [NUM_RESERVATIONS-1:0][AXI_ADDR_WIDTH-1:0]   tbl_d, tbl_q;
+        logic clr, set, match, matching_set;
+        logic [NUM_RESERVATIONS-1:0] plru_used, plru_evict_oh;
+        logic [cf_math_pkg::idx_width(NUM_RESERVATIONS)-1:0] plru_evict;
+        logic [NUM_RESERVATIONS-1:0][AXI_ID_WIDTH-1:0] tbl_id_d, tbl_id_q;
+
+        plru_tree #(
+            .ENTRIES(NUM_RESERVATIONS)
+        ) i_reservation_plru (
+            .clk_i(clk_i),
+            .rst_ni(rst_ni),
+            .used_i(plru_used),
+            .plru_o(plru_evict_oh)
+        );
+
+        onehot_to_bin #(
+            .ONEHOT_WIDTH(NUM_RESERVATIONS)
+        ) i_reservation_plru_bin (
+            .onehot(plru_evict_oh),
+            .bin(plru_evict)
+        );
+
+        always_comb begin
+            tbl_d = tbl_q;
+            tbl_id_d = tbl_id_q;
+            matching_set = 1'b0;
+            if (set) begin
+                for (genvar i = 0; i < NUM_RESERVATIONS; ++i) begin
+                    if (set_id_i == tbl_id_q[i]) begin
+                        tbl_d[i] = set_addr_i;
+                        plru_used[i] = 1'b1;
+                        matching_set = 1'b1;
+                        break;
+                    end
+                end
+                for (genvar i = 0; i < NUM_RESERVATIONS; ++i) begin
+                    if (i == plru_evict && !matching_set) begin
+                        tbl_d[i] = set_addr_i;
+                        tbl_id_d[i] = set_id_i;
+                        plru_used[i] = 1'b1;
+                    end
+                end
+            end else if (clr) begin
+                for (genvar i = 0; i < NUM_RESERVATIONS; ++i) begin
+                    if (tbl_q[i] == check_clr_addr_i) begin
+                        tbl_d[i] = '0;
+                    end
+                end
+            end
+        end
+
+        // Table-Managing Logic
+        always_comb begin
+            clr             = 1'b0;
+            set             = 1'b0;
+            set_gnt_o       = 1'b0;
+            check_res_o     = 1'b0;
+            check_clr_gnt_o = 1'b0;
+            match           = 1'b0;
+
+            if (check_clr_req_i) begin
+                for (int i = 0; i < NUM_RESERVATIONS; i++) begin
+                    match |= (tbl_q[i] == check_clr_addr_i) && (tbl_id_q[i] == check_id_i);
+                end
+                check_clr_gnt_o = 1'b1;
+                check_res_o     = match;
+                clr             = !(check_clr_excl_i && !match);
+            end else if (set_req_i) begin
+                set         = 1'b1;
+                set_gnt_o   = 1'b1;
+            end
+        end
+
+        // Registers
+        always_ff @(posedge clk_i, negedge rst_ni) begin
+            if (~rst_ni) begin
+                tbl_q   <= '0;
+                tbl_id_q <= '0;
+            end else begin
+                tbl_q   <= tbl_d;
+                tbl_id_q <= tbl_id_d;
+            end
         end
     end
 
@@ -84,6 +172,8 @@ module axi_res_tbl #(
             else $fatal(1, "AXI_ADDR_WIDTH must be greater than 0!");
         assert (AXI_ID_WIDTH > 0)
             else $fatal(1, "AXI_ID_WIDTH must be greater than 0!");
+        assert (NUM_RESERVATIONS <= N_IDS)
+            else $fatal(1, "NUM_RESERVATIONS must be less than or equal to N_IDS!");
     end
 `endif
 // pragma translate_on

--- a/src/axi_riscv_atomics.sv
+++ b/src/axi_riscv_atomics.sv
@@ -46,6 +46,8 @@ module axi_riscv_atomics
     parameter bit FULL_BANDWIDTH = 1'b1,
     /// Cut combinational path between input and output in LRSC ID queues with full bandwidth
     parameter bit CUT_OUP_POP_INP_GNT = 1'b0,
+    /// Number of simultaineous LRSC reservations (power of 2, <= 2^AXI_ID_WIDTH or <= 2^(AXI_USER_ID_MSB - AXI_USER_ID_LSB + 1))
+    parameter int unsigned NUM_RESERVATIONS = 2**AXI_ID_WIDTH,
     /// Derived Parameters (do NOT change manually!)
     localparam int unsigned AXI_STRB_WIDTH = AXI_DATA_WIDTH / 8
 ) (
@@ -494,7 +496,8 @@ module axi_riscv_atomics
         .AXI_USER_ID_LSB     (AXI_USER_ID_LSB),
         .AXI_ADDR_LSB        (AXI_ADDR_LSB),
         .FULL_BANDWIDTH      (FULL_BANDWIDTH),
-        .CUT_OUP_POP_INP_GNT (CUT_OUP_POP_INP_GNT)
+        .CUT_OUP_POP_INP_GNT (CUT_OUP_POP_INP_GNT),
+        .NUM_RESERVATIONS    (NUM_RESERVATIONS)
     ) i_lrsc (
         .clk_i              ( clk_i                 ),
         .rst_ni             ( rst_ni                ),

--- a/src/axi_riscv_atomics.sv
+++ b/src/axi_riscv_atomics.sv
@@ -47,7 +47,9 @@ module axi_riscv_atomics
     /// Cut combinational path between input and output in LRSC ID queues with full bandwidth
     parameter bit CUT_OUP_POP_INP_GNT = 1'b0,
     /// Number of simultaineous LRSC reservations (power of 2, <= 2^AXI_ID_WIDTH or <= 2^(AXI_USER_ID_MSB - AXI_USER_ID_LSB + 1))
-    parameter int unsigned NUM_RESERVATIONS = 2**AXI_ID_WIDTH,
+    parameter int unsigned NUM_RESERVATIONS = 2**(AXI_USER_AS_ID ?
+            AXI_USER_ID_MSB - AXI_USER_ID_LSB + 1
+            : AXI_ID_WIDTH),
     /// Derived Parameters (do NOT change manually!)
     localparam int unsigned AXI_STRB_WIDTH = AXI_DATA_WIDTH / 8
 ) (

--- a/src/axi_riscv_atomics_structs.sv
+++ b/src/axi_riscv_atomics_structs.sv
@@ -33,6 +33,8 @@ module axi_riscv_atomics_structs #(
   parameter int unsigned  AxiAddrLSB      = $clog2(AxiDataWidth/8),
   parameter bit           FullBandwidth   = 1,
   parameter bit           CutOupPopInpGnt = 0,
+  parameter int unsigned  NumReservations = 2**AXI_ID_WIDTH,
+
   parameter type          axi_req_t       = logic,
   parameter type          axi_rsp_t       = logic
 ) (
@@ -78,7 +80,8 @@ module axi_riscv_atomics_structs #(
     .RISCV_WORD_WIDTH    ( RiscvWordWidth  ),
     .N_AXI_CUT           ( NAxiCuts        ),
     .FULL_BANDWIDTH      ( FullBandwidth   ),
-    .CUT_OUP_POP_INP_GNT ( CutOupPopInpGnt )
+    .CUT_OUP_POP_INP_GNT ( CutOupPopInpGnt ),
+    .NUM_RESERVATIONS    ( NumReservations )
   ) i_axi_riscv_atomics_wrap (
     .clk_i,
     .rst_ni,

--- a/src/axi_riscv_atomics_structs.sv
+++ b/src/axi_riscv_atomics_structs.sv
@@ -33,7 +33,9 @@ module axi_riscv_atomics_structs #(
   parameter int unsigned  AxiAddrLSB      = $clog2(AxiDataWidth/8),
   parameter bit           FullBandwidth   = 1,
   parameter bit           CutOupPopInpGnt = 0,
-  parameter int unsigned  NumReservations = 2**AXI_ID_WIDTH,
+  parameter int unsigned  NumReservations = 2**(AxiUserAsId ?
+            AxiUserIdMsb - AxiUserIdLsb + 1
+            : AxiIdWidth),
 
   parameter type          axi_req_t       = logic,
   parameter type          axi_rsp_t       = logic

--- a/src/axi_riscv_atomics_wrap.sv
+++ b/src/axi_riscv_atomics_wrap.sv
@@ -43,6 +43,8 @@ module axi_riscv_atomics_wrap #(
     parameter bit FULL_BANDWIDTH = 1'b1,
     /// Cut combinational path between input and output in LRSC ID queues with full bandwidth
     parameter bit CUT_OUP_POP_INP_GNT = 1'b0,
+    /// Number of simultaineous LRSC reservations (power of 2, <= 2^AXI_ID_WIDTH or <= 2^(AXI_USER_ID_MSB - AXI_USER_ID_LSB + 1))
+    parameter int unsigned NUM_RESERVATIONS = 2**AXI_ID_WIDTH,
     /// Derived Parameters (do NOT change manually!)
     localparam int unsigned AXI_STRB_WIDTH = AXI_DATA_WIDTH / 8
 ) (
@@ -66,7 +68,8 @@ module axi_riscv_atomics_wrap #(
         .RISCV_WORD_WIDTH    (RISCV_WORD_WIDTH),
         .N_AXI_CUT           (N_AXI_CUT),
         .FULL_BANDWIDTH      (FULL_BANDWIDTH),
-        .CUT_OUP_POP_INP_GNT (CUT_OUP_POP_INP_GNT)
+        .CUT_OUP_POP_INP_GNT (CUT_OUP_POP_INP_GNT),
+        .NUM_RESERVATIONS    (NUM_RESERVATIONS)
     ) i_atomics (
         .clk_i           ( clk_i         ),
         .rst_ni          ( rst_ni        ),

--- a/src/axi_riscv_atomics_wrap.sv
+++ b/src/axi_riscv_atomics_wrap.sv
@@ -44,7 +44,9 @@ module axi_riscv_atomics_wrap #(
     /// Cut combinational path between input and output in LRSC ID queues with full bandwidth
     parameter bit CUT_OUP_POP_INP_GNT = 1'b0,
     /// Number of simultaineous LRSC reservations (power of 2, <= 2^AXI_ID_WIDTH or <= 2^(AXI_USER_ID_MSB - AXI_USER_ID_LSB + 1))
-    parameter int unsigned NUM_RESERVATIONS = 2**AXI_ID_WIDTH,
+    parameter int unsigned NUM_RESERVATIONS = 2**(AXI_USER_AS_ID ?
+            AXI_USER_ID_MSB - AXI_USER_ID_LSB + 1
+            : AXI_ID_WIDTH),
     /// Derived Parameters (do NOT change manually!)
     localparam int unsigned AXI_STRB_WIDTH = AXI_DATA_WIDTH / 8
 ) (

--- a/src/axi_riscv_lrsc.sv
+++ b/src/axi_riscv_lrsc.sv
@@ -48,6 +48,8 @@ module axi_riscv_lrsc #(
     parameter bit FULL_BANDWIDTH = 1'b1,
     /// Cut combinational path between input and output in ID queues with full bandwidth
     parameter bit CUT_OUP_POP_INP_GNT = 1'b0,
+    /// Number of simultaineous reservations (<= 2^AXI_ID_WIDTH or <= 2^(AXI_USER_ID_MSB - AXI_USER_ID_LSB + 1))
+    parameter int unsigned NUM_RESERVATIONS = 2**AXI_ID_WIDTH,
     /// Derived Parameters (do NOT change manually!)
     localparam int unsigned AXI_STRB_WIDTH = AXI_DATA_WIDTH / 8
 ) (
@@ -1024,7 +1026,8 @@ module axi_riscv_lrsc #(
             : slv_ar_id_i;
     axi_res_tbl #(
         .AXI_ADDR_WIDTH (AXI_ADDR_WIDTH-AXI_ADDR_LSB), // Track reservations with given granularity.
-        .AXI_ID_WIDTH   (RES_ID_WIDTH)
+        .AXI_ID_WIDTH   (RES_ID_WIDTH),
+        .NUM_RESERVATIONS (NUM_RESERVATIONS)
     ) i_art (
         .clk_i                  (clk_i),
         .rst_ni                 (rst_ni),

--- a/src/axi_riscv_lrsc.sv
+++ b/src/axi_riscv_lrsc.sv
@@ -49,7 +49,9 @@ module axi_riscv_lrsc #(
     /// Cut combinational path between input and output in ID queues with full bandwidth
     parameter bit CUT_OUP_POP_INP_GNT = 1'b0,
     /// Number of simultaineous reservations (power of 2, <= 2^AXI_ID_WIDTH or <= 2^(AXI_USER_ID_MSB - AXI_USER_ID_LSB + 1))
-    parameter int unsigned NUM_RESERVATIONS = 2**AXI_ID_WIDTH,
+    parameter int unsigned NUM_RESERVATIONS = 2**(AXI_USER_AS_ID ?
+            AXI_USER_ID_MSB - AXI_USER_ID_LSB + 1
+            : AXI_ID_WIDTH),
     /// Derived Parameters (do NOT change manually!)
     localparam int unsigned AXI_STRB_WIDTH = AXI_DATA_WIDTH / 8
 ) (

--- a/src/axi_riscv_lrsc.sv
+++ b/src/axi_riscv_lrsc.sv
@@ -48,7 +48,7 @@ module axi_riscv_lrsc #(
     parameter bit FULL_BANDWIDTH = 1'b1,
     /// Cut combinational path between input and output in ID queues with full bandwidth
     parameter bit CUT_OUP_POP_INP_GNT = 1'b0,
-    /// Number of simultaineous reservations (<= 2^AXI_ID_WIDTH or <= 2^(AXI_USER_ID_MSB - AXI_USER_ID_LSB + 1))
+    /// Number of simultaineous reservations (power of 2, <= 2^AXI_ID_WIDTH or <= 2^(AXI_USER_ID_MSB - AXI_USER_ID_LSB + 1))
     parameter int unsigned NUM_RESERVATIONS = 2**AXI_ID_WIDTH,
     /// Derived Parameters (do NOT change manually!)
     localparam int unsigned AXI_STRB_WIDTH = AXI_DATA_WIDTH / 8

--- a/src/axi_riscv_lrsc_wrap.sv
+++ b/src/axi_riscv_lrsc_wrap.sv
@@ -34,7 +34,7 @@ module axi_riscv_lrsc_wrap #(
     parameter bit FULL_BANDWIDTH = 1'b1,
     /// Cut combinational path between input and output in LRSC ID queues with full bandwidth
     parameter bit CUT_OUP_POP_INP_GNT = 1'b0,
-    /// Number of simultaineous reservations (<= 2^AXI_ID_WIDTH or <= 2^(AXI_USER_ID_MSB - AXI_USER_ID_LSB + 1))
+    /// Number of simultaineous reservations (power of 2, <= 2^AXI_ID_WIDTH or <= 2^(AXI_USER_ID_MSB - AXI_USER_ID_LSB + 1))
     parameter int unsigned NUM_RESERVATIONS = 2**AXI_ID_WIDTH,
     /// Enable debug prints (not synthesizable).
     parameter bit DEBUG = 1'b0,

--- a/src/axi_riscv_lrsc_wrap.sv
+++ b/src/axi_riscv_lrsc_wrap.sv
@@ -35,7 +35,9 @@ module axi_riscv_lrsc_wrap #(
     /// Cut combinational path between input and output in LRSC ID queues with full bandwidth
     parameter bit CUT_OUP_POP_INP_GNT = 1'b0,
     /// Number of simultaineous reservations (power of 2, <= 2^AXI_ID_WIDTH or <= 2^(AXI_USER_ID_MSB - AXI_USER_ID_LSB + 1))
-    parameter int unsigned NUM_RESERVATIONS = 2**AXI_ID_WIDTH,
+    parameter int unsigned NUM_RESERVATIONS = 2**(AXI_USER_AS_ID ?
+            AXI_USER_ID_MSB - AXI_USER_ID_LSB + 1
+            : AXI_ID_WIDTH),
     /// Enable debug prints (not synthesizable).
     parameter bit DEBUG = 1'b0,
     /// Derived Parameters (do NOT change manually!)

--- a/src/axi_riscv_lrsc_wrap.sv
+++ b/src/axi_riscv_lrsc_wrap.sv
@@ -34,6 +34,8 @@ module axi_riscv_lrsc_wrap #(
     parameter bit FULL_BANDWIDTH = 1'b1,
     /// Cut combinational path between input and output in LRSC ID queues with full bandwidth
     parameter bit CUT_OUP_POP_INP_GNT = 1'b0,
+    /// Number of simultaineous reservations (<= 2^AXI_ID_WIDTH or <= 2^(AXI_USER_ID_MSB - AXI_USER_ID_LSB + 1))
+    parameter int unsigned NUM_RESERVATIONS = 2**AXI_ID_WIDTH,
     /// Enable debug prints (not synthesizable).
     parameter bit DEBUG = 1'b0,
     /// Derived Parameters (do NOT change manually!)
@@ -60,7 +62,8 @@ module axi_riscv_lrsc_wrap #(
         .AXI_ADDR_LSB           (AXI_ADDR_LSB),
         .FULL_BANDWIDTH         (FULL_BANDWIDTH),
         .CUT_OUP_POP_INP_GNT    (CUT_OUP_POP_INP_GNT),
-        .DEBUG                  (DEBUG)
+        .DEBUG                  (DEBUG),
+        .NUM_RESERVATIONS       (NUM_RESERVATIONS)
     ) i_lrsc (
         .clk_i           ( clk_i         ),
         .rst_ni          ( rst_ni        ),

--- a/test/axi_riscv_lrsc_tb.sv
+++ b/test/axi_riscv_lrsc_tb.sv
@@ -22,7 +22,7 @@ module axi_riscv_lrsc_tb #(
     parameter int unsigned AXI_MAX_READ_TXNS = 16,
     parameter int unsigned AXI_MAX_WRITE_TXNS = 16,
     parameter int unsigned AXI_ADDR_LSB = 3,
-    parameter int unsigned NUM_RESERVATIONS = 10,
+    parameter int unsigned NUM_RESERVATIONS = 16,
     parameter bit DEBUG = 1'b0,
     // TB Parameters
     parameter int unsigned REQ_MIN_WAIT_CYCLES = 0,

--- a/test/axi_riscv_lrsc_tb.sv
+++ b/test/axi_riscv_lrsc_tb.sv
@@ -22,6 +22,7 @@ module axi_riscv_lrsc_tb #(
     parameter int unsigned AXI_MAX_READ_TXNS = 16,
     parameter int unsigned AXI_MAX_WRITE_TXNS = 16,
     parameter int unsigned AXI_ADDR_LSB = 3,
+    parameter int unsigned NUM_RESERVATIONS = 10,
     parameter bit DEBUG = 1'b0,
     // TB Parameters
     parameter int unsigned REQ_MIN_WAIT_CYCLES = 0,
@@ -100,7 +101,8 @@ module axi_riscv_lrsc_tb #(
         .AXI_MAX_READ_TXNS      (AXI_MAX_READ_TXNS),
         .AXI_MAX_WRITE_TXNS     (AXI_MAX_WRITE_TXNS),
         .AXI_ADDR_LSB           (AXI_ADDR_LSB),
-        .DEBUG                  (DEBUG)
+        .DEBUG                  (DEBUG),
+        .NUM_RESERVATIONS       (NUM_RESERVATIONS)
     ) dut (
         .clk_i  (clk),
         .rst_ni (rst_n),


### PR DESCRIPTION
If limited LR/SC support is OK, NUM_RESERVATIONS can be set to reduce how many active atomics are supported, significantly improving PPA. This means that some reservations may be cleared without another actor accessing that address, as too many actors are reserving at the same time. If the parameter is not set, existing code will remain, so is backwards-compatible.