### PR TITLE
ci: check also for `Fatal` error message

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,7 @@ stages:
     - bender script vsim -t test > compile.tcl
     - $VSIM -c -quiet -do 'source compile.tcl; quit'
     - $VSIM -c $TOPLEVEL -do "run -all"
-    - (! grep -n "Error:" transcript)
+    - (! grep -n -E "Error:|Fatal:" transcript)
 
 tests:
   extends: .test-tpl


### PR DESCRIPTION
I noted on a personal branch that the CI was passing while the simulation was failing due to a fatal error. This PR fixes the CI check accordingly.