### PR TITLE
De-assign default out_id value from inout task bus.

### DIFF
--- a/test/golden_memory.sv
+++ b/test/golden_memory.sv
@@ -331,12 +331,11 @@ package golden_model_pkg;
         endtask : read
 
         // Linearization Functions
-        logic [RES_ID_WIDTH-1:0] default_id = 0; // Systemverilog requires a assignable default value (required to make this argument optional)
         task wait_write(
             input logic [AXI_ADDR_WIDTH-1:0] addr,
             input logic [2:0]                size,
             input logic [RES_ID_WIDTH-1:0]   id,
-            inout logic [RES_ID_WIDTH-1:0]   out_id=default_id
+            inout logic [RES_ID_WIDTH-1:0]   out_id
         );
             if (out_id) begin
                 // Wait for a transaction to be through the memory controller's buffers and return its ID


### PR DESCRIPTION
**Fixes compilation errors with Cadence Xcelium.**
Xcelium seems to be overly dramatic raising:

```verilog
xmvlog: *E,DANTIN (path/to/axi_riscv_atomics-40ad8d2d0e0daa8b/test/golden_memory.sv,339|50): default value declared for output or inout argument [SystemVerilog].
```

Even if the System Verilog standard allows default values to be passed to inout task buses.
However, I see the `wait_write` task is only [invoked](https://github.com/pulp-platform/axi_riscv_atomics/blob/master/test/golden_memory.sv#L242) with the `out_id` inout  passed, so making it unoptional should not be too bad.