### PR TITLE
axi_res_tbl: assign tbl_id_d[i] when occupying an unused PLRU slot

### DIFF
--- a/src/axi_res_tbl.sv
+++ b/src/axi_res_tbl.sv
@@ -122,6 +122,7 @@ module axi_res_tbl #(
                 for (int i = 0; i < NUM_RESERVATIONS; ++i) begin
                     if (!field_in_use_q[i] && !matching_set) begin
                         tbl_d[i] = set_addr_i;
+                        tbl_id_d[i] = set_id_i;
                         plru_used[i] = 1'b1;
                         matching_set = 1'b1;
                         field_in_use_d[i] = 1'b1;


### PR DESCRIPTION
The PLRU branch of axi_res_tbl handles a `set` (LR) by trying three loops: (1) reuse the slot whose tbl_id_q[i] already matches set_id_i, (2) occupy any slot with field_in_use_q[i] == 0, (3) evict the LRU slot. Loops 1 and 3 leave tbl_id correctly assigned (loop 1 because the slot already held the right ID, loop 3 by explicit `tbl_id_d[i] = set_id_i`). Loop 2, introduced in 817e279 ("Ensure unused entries get occupied before evicting used entries"), overwrites tbl_d[i] with the new addr but does NOT update tbl_id_d[i]. The slot keeps its prior occupant's ID -- zero after reset, the just-cleared occupant's ID otherwise.

Consequence: under any configuration with NUM_RESERVATIONS less than 2**AXI_ID_WIDTH (the limited-reservations mode), an LR from a non-zero ID following reset stores the wrong ID. The matching SC then fails the `tbl_id_q[i] == check_id_i` test on the line below and is dropped, even though the reservation was set by the same master.

Reproducer (Verilator 5.046, NUM_RESERVATIONS=4, AXI_ID_WIDTH=3): after reset, issue LR(id=2, addr=0x100); two clocks later inspect tbl_id_q[0] -- it reads 0 instead of 2. With this one-line fix the slot stores id=2 as expected.