### PR TITLE
lrsc: fix spurious EXOKAY when reservation was not granted

### DIFF
--- a/src/axi_riscv_lrsc.sv
+++ b/src/axi_riscv_lrsc.sv
@@ -362,7 +362,11 @@ module axi_riscv_lrsc #(
         .full_o             (),
         .empty_o            ()
     );
-    assign rifq_inp_data.excl = ar_push_excl;
+    // Record whether the reservation was *granted*, not merely attempted.
+    // When a conflicting write is in-flight ar_push_res=0 even though
+    // ar_push_excl=1; using ar_push_excl here would cause a spurious EXOKAY
+    // on the R response (AXI4 §C8.2 violation).
+    assign rifq_inp_data.excl = ar_push_res;
 
     // Fork requests from AR into reservation table and queue of in-flight reads.
     stream_fork #(


### PR DESCRIPTION
Hi there!

rifq_inp_data.excl used ar_push_excl, so an exclusive read could return EXOKAY even when the monitor did not grant a reservation due to an in-flight conflicting write. AXI4 requires OKAY in that case, and strict AXI monitors/VIPs may flag the spurious EXOKAY.

This PR fixes this by recording excl from ar_push_res, i.e. only when the reservation is actually accepted.

Thanks!
Flavien